### PR TITLE
fixed excess header padding in mumble

### DIFF
--- a/Builds/mumble-theme/Dark.qss
+++ b/Builds/mumble-theme/Dark.qss
@@ -327,16 +327,14 @@ QHeaderView::section {
   background-color: #2d2d2d;
   border-right: 1px solid #1c1c1c;
   color: #d8d8d8;
-  padding: 4px;
-  padding-left: 8px;
-  padding-right: 20px;
+  padding: 0.3em;
   border-radius: 0; }
 
 QHeaderView::down-arrow,
 QHeaderView::up-arrow {
   margin: 1px;
   top: 1px;
-  right: 5px;
+  right: 2px;
   width: 14px; }
 
 QHeaderView::down-arrow {

--- a/Builds/mumble-theme/Lite.qss
+++ b/Builds/mumble-theme/Lite.qss
@@ -327,16 +327,14 @@ QHeaderView::section {
   background-color: #FDFDFD;
   border-right: 1px solid #D2D2D2;
   color: #111;
-  padding: 4px;
-  padding-left: 8px;
-  padding-right: 20px;
+  padding: 0.3em;
   border-radius: 0; }
 
 QHeaderView::down-arrow,
 QHeaderView::up-arrow {
   margin: 1px;
   top: 1px;
-  right: 5px;
+  right: 2px;
   width: 14px; }
 
 QHeaderView::down-arrow {


### PR DESCRIPTION
Excess padding on right wasted too much space

#### Before

![Screenshot 2022-03-25 200407](https://user-images.githubusercontent.com/54780443/160152055-74b70973-0158-4981-919b-cc706d59c23d.png)
 
#### After

![Screenshot 2022-03-25 205435](https://user-images.githubusercontent.com/54780443/160152092-4673d918-c689-4579-9d45-e7550f624ad4.png)

